### PR TITLE
Double step for deleting for quotes

### DIFF
--- a/controllers/opine/quote.controller.ts
+++ b/controllers/opine/quote.controller.ts
@@ -59,7 +59,7 @@ export const postQuote = async ({ body }: PostQuote, res?: CommonResponse) => {
 };
 
 export const patchQuote = async ({ body }: PatchQuote, res?: CommonResponse) => {
-  const { quoteId, authorId, sourceId, quote } = body;
+  const { authorId, sourceId, quote } = body;
 
   const patchData = {} as Partial<Quote>;
 
@@ -77,7 +77,9 @@ export const patchQuote = async ({ body }: PatchQuote, res?: CommonResponse) => 
     patchData.author = new ObjectId(authorId);
   }
 
-  const results = await changeQuote({ _id: new ObjectId(quoteId) }, { $set: patchData });
+  const results = await changeQuote(body.quoteId ? { _id: new ObjectId(body.quoteId) } : { number: body.number }, {
+    $set: patchData,
+  });
 
   if (results.modifiedCount === 0) res?.setStatus(404).send({ message: null, error: "Quote not found" });
   else res?.sendStatus(200);

--- a/controllers/opine/quote.controller.ts
+++ b/controllers/opine/quote.controller.ts
@@ -7,6 +7,7 @@ import {
 import { ObjectId } from "../../deps.ts";
 import { pretifyIds } from "../../utils/pretifyId.ts";
 import Quote from "../../types/collections/quote.type.ts";
+import isMongoId from "../../types/typeGuards/isMongoId.ts";
 import { getSourceById } from "../mongo/source.controller.ts";
 import { getAuthorById } from "../mongo/author.controller.ts";
 import CommonResponse from "../../types/commonResponse.type.ts";
@@ -87,8 +88,11 @@ export const patchQuote = async ({ body }: PatchQuote, res?: CommonResponse) => 
   return results;
 };
 
-export const deleteQuote = async ({ params }: DeleteQuote, res?: CommonResponse) => {
-  const results = await changeQuote({ _id: new ObjectId(params._id) }, { $set: { archived: true } });
+export const deleteQuote = async ({ params: { idOrNumber } }: DeleteQuote, res?: CommonResponse) => {
+  const results = await changeQuote(
+    isMongoId(idOrNumber) ? { _id: new ObjectId(idOrNumber) } : { number: +idOrNumber },
+    { $set: { archived: true } }
+  );
 
   if (results.modifiedCount === 0) res?.setStatus(404).send({ message: null, error: "Quote not found" });
   else res?.sendStatus(200);

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -10,12 +10,14 @@ import * as $3 from "./routes/_middleware.tsx";
 import * as $4 from "./routes/author/new.tsx";
 import * as $5 from "./routes/index.tsx";
 import * as $6 from "./routes/quote/[id].tsx";
-import * as $7 from "./routes/quote/newOrEdit.tsx";
-import * as $8 from "./routes/signin.tsx";
-import * as $9 from "./routes/signout.tsx";
-import * as $10 from "./routes/source/delete/[id].tsx";
-import * as $11 from "./routes/source/newOrEdit.tsx";
-import * as $12 from "./routes/sources.tsx";
+import * as $7 from "./routes/quote/_middleware.tsx";
+import * as $8 from "./routes/quote/delete/[id].tsx";
+import * as $9 from "./routes/quote/newOrEdit.tsx";
+import * as $10 from "./routes/signin.tsx";
+import * as $11 from "./routes/signout.tsx";
+import * as $12 from "./routes/source/delete/[id].tsx";
+import * as $13 from "./routes/source/newOrEdit.tsx";
+import * as $14 from "./routes/sources.tsx";
 import * as $$0 from "./islands/AuthorSourceSelector.tsx";
 import * as $$1 from "./islands/LastSentTime.tsx";
 
@@ -28,12 +30,14 @@ const manifest = {
     "./routes/author/new.tsx": $4,
     "./routes/index.tsx": $5,
     "./routes/quote/[id].tsx": $6,
-    "./routes/quote/newOrEdit.tsx": $7,
-    "./routes/signin.tsx": $8,
-    "./routes/signout.tsx": $9,
-    "./routes/source/delete/[id].tsx": $10,
-    "./routes/source/newOrEdit.tsx": $11,
-    "./routes/sources.tsx": $12,
+    "./routes/quote/_middleware.tsx": $7,
+    "./routes/quote/delete/[id].tsx": $8,
+    "./routes/quote/newOrEdit.tsx": $9,
+    "./routes/signin.tsx": $10,
+    "./routes/signout.tsx": $11,
+    "./routes/source/delete/[id].tsx": $12,
+    "./routes/source/newOrEdit.tsx": $13,
+    "./routes/sources.tsx": $14,
   },
   islands: {
     "./islands/AuthorSourceSelector.tsx": $$0,

--- a/router/quote.router.ts
+++ b/router/quote.router.ts
@@ -10,6 +10,6 @@ quoteRouter.post("/quote", s.postQuote, c.postQuote);
 
 quoteRouter.patch("/quote", s.patchQuote, c.patchQuote);
 
-quoteRouter.delete("/quote/:id", s.deleteQuote, c.deleteQuote);
+quoteRouter.delete("/quote/:idOrNumber", s.deleteQuote, c.deleteQuote);
 
 export default quoteRouter;

--- a/routes/_404.tsx
+++ b/routes/_404.tsx
@@ -1,7 +1,19 @@
+import Metas from "../components/Metas.tsx";
+import { UnknownPageProps, Head } from "../deps.ts";
 import Typography from "../components/Typography.tsx";
-import { UnknownPageProps } from "../deps.ts";
 
 export default function NotFoundPage({ url }: UnknownPageProps) {
+  // 404 for quotes
+  if (url.pathname.startsWith("/quote"))
+    return (
+      <>
+        <Head>
+          <Metas description="" title="Quote not found" />
+        </Head>
+        <Typography variant="h4">Quote not found</Typography>{" "}
+      </>
+    );
+
   return (
     <>
       <Typography variant="h1">404 not found</Typography>

--- a/routes/_middleware.tsx
+++ b/routes/_middleware.tsx
@@ -22,6 +22,8 @@ export const handler = [
     const cookies = getCookies(req.headers);
 
     for (const key of Object.keys(cookies) as (keyof State)[]) {
+      if (key === "quoteExists") continue;
+
       const isValid = await verifySignedCookie(req.headers, key);
       if (isValid === false) {
         invalidKeys.push(key);

--- a/routes/quote/_middleware.tsx
+++ b/routes/quote/_middleware.tsx
@@ -14,6 +14,8 @@ export async function handler(req: Request, ctx: MiddlewareHandlerContext<State>
     const groups = pattern.exec(req.url)?.pathname.groups as { id?: string } | undefined;
     if (!groups || !groups.id) continue;
 
+    if (groups.id === "new") break;
+
     const filter: Filter<Quote> = { archived: { $ne: true } };
     if (isMongoId(groups.id)) {
       filter._id = new ObjectId(groups.id);

--- a/routes/quote/_middleware.tsx
+++ b/routes/quote/_middleware.tsx
@@ -1,0 +1,38 @@
+import redirect from "../../utils/redirect.ts";
+import { State } from "../../types/state.type.ts";
+import Quote from "../../types/collections/quote.type.ts";
+import isMongoId from "../../types/typeGuards/isMongoId.ts";
+import { getQuote } from "../../controllers/mongo/quote.controller.ts";
+import { Filter, MiddlewareHandlerContext, ObjectId } from "../../deps.ts";
+
+const urlPatterns = ["/quote/edit/:id", "/quote/delete/:id", "/quote/:id"].map(
+  (pathname) => new URLPattern({ pathname })
+);
+
+export async function handler(req: Request, ctx: MiddlewareHandlerContext<State>) {
+  for (const pattern of urlPatterns) {
+    const groups = pattern.exec(req.url)?.pathname.groups as { id?: string } | undefined;
+    if (!groups || !groups.id) continue;
+
+    const filter: Filter<Quote> = { archived: { $ne: true } };
+    if (isMongoId(groups.id)) {
+      filter._id = new ObjectId(groups.id);
+    } else {
+      filter.number = +groups.id;
+      if (isNaN(filter.number)) {
+        ctx.state.quoteExists = false;
+        return ctx.next();
+      }
+    }
+
+    const possibleQuote = await getQuote(filter, { projection: { number: 1 } });
+    ctx.state.quoteExists = Boolean(possibleQuote);
+
+    // If using the ObjectId, redirect to the quote number
+    if (filter._id && possibleQuote) return redirect(pattern.pathname.replace(":id", `${possibleQuote.number}`));
+
+    break;
+  }
+
+  return ctx.next();
+}

--- a/routes/quote/delete/[id].tsx
+++ b/routes/quote/delete/[id].tsx
@@ -1,0 +1,57 @@
+import redirect from "../../../utils/redirect.ts";
+import { State } from "../../../types/state.type.ts";
+import Typography from "../../../components/Typography.tsx";
+import { Handlers, PageProps, Head } from "../../../deps.ts";
+import Button, { getButtonClasses } from "../../../components/Button.tsx";
+import { deleteQuote } from "../../../controllers/opine/quote.controller.ts";
+
+interface DeleteQuoteProps {
+  quoteNumber: number;
+}
+
+export const handler: Handlers<DeleteQuoteProps, State> = {
+  async GET(_, ctx) {
+    if (!ctx.state.quoteExists) return ctx.renderNotFound();
+
+    const id = +ctx.params.id;
+
+    return await ctx.render({ quoteNumber: id });
+  },
+
+  async POST(_, ctx) {
+    if (!ctx.state.quoteExists) return ctx.renderNotFound();
+
+    await deleteQuote({ params: { idOrNumber: ctx.params.id } });
+
+    return redirect("/");
+  },
+};
+
+export default function DeleteSource({ data: { quoteNumber } }: PageProps<DeleteQuoteProps>) {
+  return (
+    <>
+      <Head>
+        <title>Delete quote</title>
+      </Head>
+
+      <Typography variant="h2">
+        Delete quote #<code>{quoteNumber}</code>
+      </Typography>
+
+      <Typography>
+        This action <b>can</b> be undone; this will only archive the quote.
+      </Typography>
+
+      <div class="mt-9 flex justify-center align-center items-center mt-2 gap-8">
+        <a href={`/quote/edit/${quoteNumber}`} class={getButtonClasses("blue")}>
+          Go back
+        </a>
+        <form method="post">
+          <Button class="py-2 px-4" type="submit" color="red">
+            Yes, delete
+          </Button>
+        </form>
+      </div>
+    </>
+  );
+}

--- a/schemas/quote.schema.ts
+++ b/schemas/quote.schema.ts
@@ -2,6 +2,7 @@ import { a, joi, id } from "./schemaUtils.ts";
 import { MESSAGE_LENGTH_LIMIT } from "../constants.ts";
 
 const quote = joi.string().max(MESSAGE_LENGTH_LIMIT).min(5);
+const number = joi.number().integer().min(1);
 
 export const getQuotes = a(joi.object({ authorId: id.required() }), "params");
 
@@ -16,7 +17,8 @@ export const postQuote = a(
 export const patchQuote = a(
   joi
     .object({
-      quoteId: id.required(),
+      quoteId: id,
+      number: number,
 
       quote: quote,
       authorId: id,
@@ -24,7 +26,8 @@ export const patchQuote = a(
       // You can't archive a quote, for that you have to delete it
       archived: joi.allow(false),
     })
+    .xor("quoteId", "number")
     .or("quote", "sourceId", "authorId", "archive")
 );
 
-export const deleteQuote = a(joi.object({ id: id.required() }), "params");
+export const deleteQuote = a(joi.object({ idOrNumber: joi.alternatives().try(id, number).required() }), "params");

--- a/types/api/quote.type.ts
+++ b/types/api/quote.type.ts
@@ -17,4 +17,4 @@ export type PatchQuote = CommonRequestPartial<
   )
 >;
 
-export type DeleteQuote = CommonRequestPartial<undefined, undefined, { _id: string }>;
+export type DeleteQuote = CommonRequestPartial<undefined, undefined, { idOrNumber: string }>;

--- a/types/api/quote.type.ts
+++ b/types/api/quote.type.ts
@@ -4,12 +4,17 @@ export type GetQuotes = CommonRequestPartial<undefined, undefined, { authorId: s
 
 export type PostQuote = CommonRequestPartial<{ quote: string; sourceId: string | null; authorId: string }>;
 
-export type PatchQuote = CommonRequestPartial<{
-  quote?: string;
-  quoteId: string;
-  archived?: false;
-  authorId?: string;
-  sourceId?: string | null;
-}>;
+export type PatchQuote = CommonRequestPartial<
+  {
+    quote?: string;
+    archived?: false;
+    authorId?: string;
+    sourceId?: string | null;
+  } & (
+    | { quoteId?: never; number: number }
+    // Either quoteId or number must be provided, but not both
+    | { quoteId: string; number?: never }
+  )
+>;
 
 export type DeleteQuote = CommonRequestPartial<undefined, undefined, { _id: string }>;

--- a/types/state.type.ts
+++ b/types/state.type.ts
@@ -2,4 +2,6 @@ export interface State {
   authToken: string | undefined;
   authorId?: string;
   sourceId?: string;
+  // This will only be set for components under /quote
+  quoteExists?: boolean;
 }


### PR DESCRIPTION
![image](https://github.com/J053Fabi0/Ayn-Rand-Frases-Bot-Telegram/assets/12930717/7f0ef14d-4e96-418d-a0bb-376d633c8974)

Also created middleware that checks the existence of quotes. It works under the `/quote` route. This removes repeated code from all the routes that needed to check that. It automatically redirects to using the `number` if using the `ObjectId`.